### PR TITLE
Added $lineheightmod to ktype, Added kunit function

### DIFF
--- a/_knife.sass
+++ b/_knife.sass
@@ -133,7 +133,7 @@ $outputrems: 		true !default
 	@include remType($px, $kb)
 
 // type mixin
-@mixin ktype($scale, $before: 0, $after: 0, $lineheightmod: 0, $offset: 0, $pull: false, $push: false, $ie: $ie8compatability)
+@mixin ktype($scale, $before: 0, $after: 0, $lineheightmod: 0, $offset: 0, $pull: 0, $push: 0, $ie: $ie8compatability)
 	
 	// setup what we've got to work with
 	$kb : 		ceil($body-font-size * $body-line-height)
@@ -149,20 +149,20 @@ $outputrems: 		true !default
 		$new-line-height: 	ceil($new-font-size / $kb) * $kb
 
 		// push and pull, to be deprecated, see below
-		@if $pull != false
+		@if $pull != 0
 			$m: ($pull / 2)
 			$new-line-height: $new-line-height - ($new-line-height*$m)
-		@else if $push != false
+		@else if $push != 0
 			$m: ($push / 2)
 			$new-line-height: $new-line-height + ($new-line-height*$m)
 
-		//lineheightmod to replace push and pull with a single value, easy declare eg. to bump up lineheight by one whole line (2 half lines) for an element ktype(0,1,1,2)
-		@if $lineheightmod < 0
-			$m: ($lineheightmod / 2)
-			$new-line-height: $new-line-height - ($new-line-height*$m)
-		@else if $lineheightmod > 0
-			$m: ($lineheightmod / 2)
-			$new-line-height: $new-line-height + ($new-line-height*$m)
+	//lineheightmod to replace push and pull with a single value, easy declare eg. to bump up lineheight by one whole line (2 half lines) for an element ktype(0,1,1,2)
+	@if $lineheightmod < 0
+		$m: ($lineheightmod / 2)
+		$new-line-height: $new-line-height - ($new-line-height*$m)
+	@else if $lineheightmod > 0
+		$m: ($lineheightmod / 2)
+		$new-line-height: $new-line-height + ($new-line-height*$m)
 	
 	// offset
 	@if $offset != 0


### PR DESCRIPTION
Added $lineheightmod parameter to the ktype mixin, to replace push and pull in the future with a single value. It takes negative and positive integers like the scale unit, corresponding to half-line modificaitons to the lineheight of the output typographic element. eg. use ktype(0,1,0,2) to add a whole baseline unit to the lineheight.

Added kunit function for non-type vertical rythm arrangements, simply declare kunit(X) to output X baseline height in pixels, it also accepts a second [default:false] parameter to output in rem units instead. eg. `div { margin-top: kunit(2, true); }`
for 2 baseline units equivalent in rems. This is useful for spacing and sizing your layout units and rapid prototyping of frameworks.
